### PR TITLE
First patch version release for webpack-cmd-shell-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 # JetBrains
 # ==============
 .idea/
+
+# Node Modules
+# ==============
+package-lock.json
+node_modules/
+
+# Webpack Files
+# ==============
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+ Copyright (c) 2016
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const _ = require('lodash');
+
+const defaultSettings = {
+    beforeCompile: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'starting', 'compile']
+    }],
+    onMake: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'compiling']
+    }],
+    afterCompile: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'compiling']
+    }],
+    onEmit: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'emitting', 'files']
+    }],
+    afterEmit: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'emitting', 'files']
+    }],
+    whenDone: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'building']
+    }],
+    verbose: false
+};
+
+const APPLY = 'apply';
+const BEFORE_COMPILE = 'compilation';
+const ON_MAKE = 'make';
+const AFTER_COMPILE = 'after-compile';
+const ON_EMIT = 'emit';
+const AFTER_EMIT = 'after-emit';
+const WHEN_DONE = 'done';
+
+let classCallCheck = function (instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError("Cannot call a class as a function");
+    }
+};
+
+let createClass = function () {
+    function defineProperties(target, props) {
+        for (let i = 0; i < props.length; i++) {
+            let descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.writable = "value" in descriptor;
+            descriptor.configurable = true;
+
+            Object.defineProperty(target, descriptor.key, descriptor);
+        }
+    }
+
+    return function (Constructor, protoProps, staticProps) {
+        if (protoProps) defineProperties(Constructor.prototype, protoProps);
+        if (staticProps) defineProperties(Constructor, staticProps);
+        return Constructor;
+    };
+}();
+
+let WebpackCmdShellPlugin = function () {
+    let self;
+    function WebpackCmdShellPlugin(settings) {
+        classCallCheck(this, WebpackCmdShellPlugin);
+
+        self = this;
+        self.settings = _.assign({}, defaultSettings, settings);
+    }
+
+    createClass(WebpackCmdShellPlugin, [{
+        key: APPLY,
+        value: function apply(compiler) {
+
+            compiler.plugin(BEFORE_COMPILE, self[BEFORE_COMPILE]);
+            compiler.plugin(ON_MAKE, self[ON_MAKE]);
+            compiler.plugin(AFTER_COMPILE, self[AFTER_COMPILE]);
+            compiler.plugin(ON_EMIT, self[ON_EMIT]);
+            compiler.plugin(AFTER_EMIT, self[AFTER_EMIT]);
+            compiler.plugin(WHEN_DONE, self[WHEN_DONE]);
+        }
+    }, {
+        key: BEFORE_COMPILE,
+        value: function beforeCompile(compilation) {
+            if (self.settings.beforeCompile) {
+                console.log(self.settings.beforeCompile);
+            }
+        }
+    }, {
+        key: ON_MAKE,
+        value: function onMake(compilation) {
+            console.log('On make invoked');
+            if (self.settings.onMake) {
+                console.log(self.settings.onMake);
+            }
+        }
+    }, {
+        key: AFTER_COMPILE,
+        value: function afterCompile(compilation) {
+            console.log('After compile invoked');
+            if (self.settings.afterCompile) {
+                console.log(self.settings.afterCompile);
+            }
+        }
+    }, {
+        key: ON_EMIT,
+        value: function onEmit(compilation, callback) {
+            if (self.settings.onEmit) {
+                console.log(self.settings.onEmit);
+            }
+            callback();
+        }
+    }, {
+        key: AFTER_EMIT,
+        value: function afterEmit(compilation) {
+            if (self.settings.afterEmit) {
+                console.log(self.settings.afterEmit);
+            }
+        }
+    }, {
+        key: WHEN_DONE,
+        value: function whenDone(compilation) {
+            if (self.settings.whenDone) {
+                console.log(self.settings.whenDone);
+            }
+        }
+    }]);
+    return WebpackCmdShellPlugin;
+}();
+
+module.exports = WebpackCmdShellPlugin;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run flexible and configurable shell commands through each step of the webpack build process",
   "main": "index.js",
   "scripts": {
-    "test": "echo Running Tests"
+    "test": "webpack"
   },
   "repository": {
     "type": "git",
@@ -22,5 +22,14 @@
   "bugs": {
     "url": "https://github.com/GSCBInc/webpack-cmd-shell-plugin/issues"
   },
-  "homepage": "https://github.com/GSCBInc/webpack-cmd-shell-plugin#readme"
+  "homepage": "https://github.com/GSCBInc/webpack-cmd-shell-plugin#readme",
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-preset-es2015-rollup": "^3.0.0",
+    "eslint": "^4.19.1",
+    "lodash": "^4.17.5",
+    "rollup": "^0.57.1",
+    "rollup-plugin-babel": "^3.0.3",
+    "webpack": "^3.5.0"
+  }
 }

--- a/src/webpack-cmd-shell-plugin.js
+++ b/src/webpack-cmd-shell-plugin.js
@@ -1,0 +1,54 @@
+const _ = require('lodash');
+
+const BEFORE_COMPILE = 'compilation';
+
+const DEFAULT_SETTINGS = {
+    beforeCompile: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'Compiling']
+    }],
+    verbose: false
+};
+let self = {};
+
+self.createCommandObjectFromString = function (commandString) {
+    return commandString;
+};
+
+self.parseCommand = function (command) {
+
+    if (_.isString(command)) {
+
+    }
+    else if (_.isArray(command)) {
+
+    }
+    else if (_.isObject(command)) {
+
+    }
+
+    return command;
+};
+
+class WebpackCmdShellPlugin {
+
+    constructor (settings) {
+        this.settings = _.assign(DEFAULT_SETTINGS, settings);
+    }
+
+    beforeCompile (compilation) {
+        if (this.settings.verbose) {
+
+        }
+        if (this.settings.beforeCompile) {
+            this.settings.beforeCompile = self.parseCommand(this.settings.beforeCompile);
+        }
+    }
+
+    apply (compiler) {
+
+        compiler.plugin(BEFORE_COMPILE, this.beforeCompile);
+    }
+}
+
+export default WebpackCmdShellPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const WebpackCmdShellPlugin = require('./lib');
+
+let WebpackCmdShellPluginConfig = new WebpackCmdShellPlugin({
+    beforeCompile: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'starting', 'compile']
+    }],
+    onMake: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'compiling']
+    }],
+    afterCompile: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'compiling']
+    }],
+    onEmit: [{
+        command: 'echo',
+        args: ['Webpack', 'is', 'emitting', 'files']
+    }],
+    afterEmit: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'emitting', 'files']
+    }],
+    whenDone: [{
+        command: 'echo',
+        args: ['Webpack', 'has', 'finished', 'building']
+    }],
+
+    verbose: false
+});
+module.exports = function () {
+
+    return {
+        entry: path.resolve(__dirname, 'src/index.js'),
+        output: {
+            path: path.resolve(__dirname, 'dist'),
+            filename: 'bundle.js'
+        },
+        plugins: [WebpackCmdShellPluginConfig]
+    };
+};


### PR DESCRIPTION
It appears that none of the other webpack plugin hooks are firing except for the compilation and make process. Releasing the first patch version of webpack-cmd-shell-plugin to see if a more mature webpack configuration invokes the firing of these plugin hook callbacks.